### PR TITLE
Auto-remove for missing receivers

### DIFF
--- a/src/main/java/net/licks92/WirelessRedstone/Channel/WirelessReceiver.java
+++ b/src/main/java/net/licks92/WirelessRedstone/Channel/WirelessReceiver.java
@@ -193,6 +193,15 @@ public class WirelessReceiver implements ConfigurationSerializable, IWirelessPoi
 			if (!WirelessRedstone.WireBox.isValidLocation(block))
 			{
 				WirelessRedstone.WireBox.signWarning(block, 1);
+				for(WirelessReceiver receiver : receivers)
+		{
+			if(receiver.getX() == loc.getBlockX() && receiver.getZ() == loc.getBlockZ() && receiver.getY() == loc.getBlockY())
+			{
+				receivers.remove(receiver);
+				return;
+			}
+		}
+	}
 			}
 			else
 			{
@@ -206,7 +215,16 @@ public class WirelessReceiver implements ConfigurationSerializable, IWirelessPoi
 			
 			if (!WirelessRedstone.WireBox.isValidWallLocation(block))
 			{
-				WirelessRedstone.WireBox.signWarning(block, 1);
+				WirelessRedstone.WireBox.signWarning(block, 1);	
+			for(WirelessReceiver receiver : receivers)
+		{
+			if(receiver.getX() == loc.getBlockX() && receiver.getZ() == loc.getBlockZ() && receiver.getY() == loc.getBlockY())
+			{
+				receivers.remove(receiver);
+				return;
+			}
+		}
+	}
 			}
 			else
 			{


### PR DESCRIPTION
Added an auto-remover for missing receivers, in my server sometimes receivers don't get destroyed, (if you break them they don't get removed from the config). This should automatically remove them. (There could be a config option for this)