### PR TITLE
V2.6.2 First update to Minecraft 1.9.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<name>WirelessRedstone</name>
 	<groupId>net.licks92</groupId>
 	<artifactId>WirelessRedstone</artifactId>
-	<version>2.6.1</version>
+	<version>2.6.2</version>
 	<url>http://dev.bukkit.org/server-mods/wireless-redstone/</url>
 	<description>Wireless Redstone plugin for bukkit.</description>
 
@@ -65,19 +65,19 @@
 		<dependency>
 			<groupId>org.bukkit</groupId>
 			<artifactId>bukkit</artifactId>
-			<version>1.8-R0.1-SNAPSHOT</version>
+			<version>1.9-R0.1-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>net.milkbowl.vault</groupId>
 			<artifactId>Vault</artifactId>
 			<scope>system</scope>
 			<systemPath>${basedir}/lib/Vault.jar</systemPath>
-			<version>1.2.22-SNAPSHOT</version>
+			<version>1.3.2-SNAPSHOT</version>
 		</dependency>
 		<dependency>
 			<groupId>com.sk89q.worldedit</groupId>
 			<artifactId>worldedit-bukkit</artifactId>
-			<version>6.0.1</version>
+			<version>6.1</version>
 			<type>jar</type>
 			<scope>compile</scope>
 		</dependency>

--- a/src/main/java/net/licks92/WirelessRedstone/Listeners/WirelessBlockListener.java
+++ b/src/main/java/net/licks92/WirelessRedstone/Listeners/WirelessBlockListener.java
@@ -221,7 +221,7 @@ public class WirelessBlockListener implements Listener {
 		}
 
 		BlockFace bf = BlockFace.SELF;
-		if (WirelessRedstone.getBukkitVersion().contains("v1_8")) {
+		//if (WirelessRedstone.getBukkitVersion().contains("v1_8")) {
 			if (event.getBlock().getType() == Material.LEVER) {
 				Lever l = (Lever) event.getBlock().getState().getData();
 				BlockRedstoneEvent e = new BlockRedstoneEvent(event.getBlock()
@@ -287,7 +287,7 @@ public class WirelessBlockListener implements Listener {
 					return;
 				}
 			}
-		}
+		//}
 
 	}
 


### PR DESCRIPTION
I have made some inital changes to pom.xml and WirelessBlockListener so Wireless redstone works on Minecraft 1.9. If you dont want to maintail the plugin anymore then I'm ready to take over. 